### PR TITLE
Fix potential resource leak in fileInputStream

### DIFF
--- a/src/main/java/com/aws/greengrass/sitewatch/videouploader/mkv/MkvFilesInputStream.java
+++ b/src/main/java/com/aws/greengrass/sitewatch/videouploader/mkv/MkvFilesInputStream.java
@@ -131,8 +131,9 @@ public class MkvFilesInputStream extends InputStream {
                 mkvStartTime = mkvTimestamp;
             }
 
+            FileInputStream fileInputStream = null;
             try {
-                FileInputStream fileInputStream = new FileInputStream(mkvFile);
+                fileInputStream = new FileInputStream(mkvFile);
                 final StreamingMkvReader streamingMkvReader =
                         StreamingMkvReader.createDefault(
                                 new InputStreamParserByteSource(fileInputStream));
@@ -145,7 +146,6 @@ public class MkvFilesInputStream extends InputStream {
                 } else {
                     log.debug("No data was merged from file " +  mkvFile.getAbsolutePath());
                     closeMkvInputStream();
-                    fileInputStream.close();
                 }
             } catch (FileNotFoundException exception) {
                 log.error("File not found " + mkvFile.getAbsolutePath());
@@ -156,8 +156,14 @@ public class MkvFilesInputStream extends InputStream {
                 mkvIterator.previous();
                 closeMkvInputStream();
                 break;
-            } catch (IOException e) {
-                log.error("Unable to close fileInputStream");
+            } finally {
+                try {
+                    if (fileInputStream != null) {
+                        fileInputStream.close();
+                    }
+                } catch (IOException exception) {
+                    log.error("Failed to close fileInputStream");
+                }
             }
         }
 


### PR DESCRIPTION
As fileInputStream is created, it may not be closed properly if exceptions happened. This commit put close() in the final clause and make sure it's closed in the end.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
