### PR TITLE
fix: logs4j upgraded due to security issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,13 +74,13 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.8</version>
+            <version>2.15.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.8</version>
+            <version>2.15.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Log4j needs to be upgraded to resolve https://github.com/awslabs/aws-greengrass-labs-kvs-stream-uploader/security/dependabot/pom.xml/org.apache.logging.log4j:log4j-core/open 
Tested this with unit tests which prints log statements. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
